### PR TITLE
Feature/api update 2.4.1

### DIFF
--- a/recombee.cfc
+++ b/recombee.cfc
@@ -592,7 +592,7 @@ component {
 	function batch(
 		string databaseId= this.defaultDatabaseId
 	,	required array requests
-		 boolean distinctRecomms
+	,	boolean distinctRecomms
 	) {
 		var out= this.runRequest( api= "POST /{databaseId}/batch/", argumentCollection= arguments );
 		out.batchSuccess= true;
@@ -762,7 +762,7 @@ component {
 			}
 		}
 		this.debugLog( "API Add Batch: #uCase( out.method )#: #out.path#" );
-		if ( request.debug && request.dump ) {
+		if ( this.debug ) {
 			this.debugLog( out );
 		}
 		arrayAppend( b, out );

--- a/recombee.cfc
+++ b/recombee.cfc
@@ -228,6 +228,7 @@ component {
 	,	string timestamp
 	,	numeric duration
 	,	boolean cascadeCreate
+	,	string recommId
 	,	array batch
 	) {
 		arguments.timestamp= this.zDateFormat( arguments.timestamp ?: "" );
@@ -275,6 +276,7 @@ component {
 	,	numeric amount
 	,	numeric price
 	,	numeric profit
+	,	string recommId
 	,	array batch
 	) {
 		arguments.timestamp= this.zDateFormat( arguments.timestamp ?: "" );
@@ -321,6 +323,7 @@ component {
 	,	string timestamp
 	,	numeric rating
 	,	boolean cascadeCreate
+	,	string recommId
 	,	array batch
 	) {
 		arguments.timestamp= this.zDateFormat( arguments.timestamp ?: "" );
@@ -367,6 +370,7 @@ component {
 	,	boolean cascadeCreate
 	,	numeric amount
 	,	numeric price
+	,	string recommId
 	,	array batch
 	) {
 		arguments.timestamp= this.zDateFormat( arguments.timestamp ?: "" );
@@ -411,6 +415,7 @@ component {
 	,	required string itemId
 	,	string timestamp
 	,	boolean cascadeCreate
+	,	string recommId
 	,	array batch
 	) {
 		arguments.timestamp= this.zDateFormat( arguments.timestamp ?: "" );

--- a/recombee.cfc
+++ b/recombee.cfc
@@ -462,6 +462,7 @@ component {
 	,	string booster
 	,	boolean cascadeCreate
 	,	string scenario
+	,	string logic
 	,	boolean returnProperties= false
 	,	string includedProperties
 	,	numeric diversity
@@ -473,7 +474,7 @@ component {
 		if ( len( arguments.includedProperties ) ) {
 			arguments.returnProperties= true;
 		}
-		return this.runRequest( api= "GET /{databaseId}/users/{userId}/recomms/", argumentCollection= arguments );
+		return this.runRequest( api= "GET /{databaseId}/recomms/users/{userId}/items/", argumentCollection= arguments );
 	}
 
 	function getItemRecommendations(
@@ -497,31 +498,7 @@ component {
 		if ( len( arguments.includedProperties ) ) {
 			arguments.returnProperties= true;
 		}
-		return this.runRequest( api= "POST /{databaseId}/items/{itemId}/recomms/", argumentCollection= arguments );
-	}
-
-	function getItemRecommendations(
-		string databaseId= this.defaultDatabaseId
-	,	required string itemId
-	,	required numeric count
-	,	string targetUserId
-	,	numeric userImpact
-	,	string filter
-	,	string booster
-	,	boolean cascadeCreate
-	,	string scenario
-	,	boolean returnProperties= false
-	,	string includedProperties
-	,	numeric diversity
-	,	string minRelevance
-	,	numeric rotationRate
-	,	numeric rotationTime
-	,	array batch
-	) {
-		if ( len( arguments.includedProperties ) ) {
-			arguments.returnProperties= true;
-		}
-		return this.runRequest( api= "POST /{databaseId}/items/{itemId}/recomms/", argumentCollection= arguments );
+		return this.runRequest( api= "POST /{databaseId}/recomms/items/{itemId}/items/", argumentCollection= arguments );
 	}
 
 	// ---------------------------------------------------------------------------------------------------------- 
@@ -658,6 +635,7 @@ component {
 		,	verb= listFirst( arguments.api, " " )
 		,	requestUrl= listRest( arguments.api, " " )
 		};
+
 		structDelete( out.args, "api" );
 		// replace {var} in url 
 		for ( item in out.args ) {


### PR DESCRIPTION
Hi Jordan. I've included in this pull request a couple minor typo fixes and some additional changes to the API based on Recombee updates. The changes are as follows:

- added `recommId` parameter to various add interaction methods. This allows the user to specify when a view/cart addition/etc was a result of a recommendation. I believe this helps Recombee train it's model by providing a feedback loop.

- updated the item to user and item to item recommendation methods to use the newer methods introduced in Recombee 2.2. This is a breaking change as the response format for these methods is slightly different than the deprecated methods. So I would be open to modifying this change if you think it would be better to keep the existing methods in place. We could add new methods for these, or add a switch somewhere (this.apiVersion?) which would swap out which methods are used.

Let me know what you think. Thanks for sharing this project, it's been super useful to me. 